### PR TITLE
feat: add `TEXT` type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "umbra"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "criterion",
  "fake",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "umbra"
 description = "A blazingly fast (and hungry) database"
-version = "1.7.0"
+version = "1.7.1"
 edition = "2021"
 
 [target.'cfg(unix)'.dependencies]

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -1,4 +1,4 @@
-# UMBRA BINARY PROTOCOL v0.1
+# UMBRA BINARY PROTOCOL v0.2
 
 **The Shadow Whisper**
 
@@ -8,14 +8,16 @@
 Each message is structured as follows:
 
 [ 4 bytes ] - SQL Content length (u32, little-endian)
+
 [ 1 byte  ] - Message type (ASCII character)
+
 [ n bytes ] - Payload (depends on message type)
 
 ## Message Types:
 
- - (+) -> (0x2B) - `QuerySet` Response
- - (!) -> (0x21) - Empty / OK Response
- - (-) -> (0x2D) - Error Response
+(+) -> (0x2B) - `QuerySet` Response
+(!) -> (0x21) - Empty / OK Response
+(-) -> (0x2D) - Error Response
 
 ## Payload Details:
 
@@ -25,7 +27,9 @@ Each message is structured as follows:
 
 For each column:
   [ 2 bytes ] - Column name length (u16, LE)
+
   [ n bytes ] - Column name (UTF-8)
+
   [ 1 byte  ] - Type code (see below)
       If `VARCHAR`:
         [ 4 bytes ] - Max length (u32, LE)
@@ -64,6 +68,7 @@ Integer Types:
 
 String Types:
  - 0x40 - `VARCHAR` (requires additional 4-byte max length)
+ - 0x41 - `TEXT` (no max length field)
 
 Temporal Types:
  - 0x50 - `DATE`

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ CREATE TABLE shadow_agents (
 - [x] `VARCHAR`
 - [x] `BOOLEAN`
 - [ ] `DECIMAL`
-- [ ] `TEXT`
+- [x] `TEXT` (the loquacious one)
 - [x] Temporal types (because time flies when... I ran out of jokes)
     - [x] `DATE`
     - [x] `TIME`

--- a/src/core/storage/tuple.rs
+++ b/src/core/storage/tuple.rs
@@ -164,6 +164,15 @@ pub(crate) fn size_of(tuple: &[Value], schema: &Schema) -> usize {
 
                 utf_8_length_bytes(max) + string.as_bytes().len()
             }
+            Type::Text => {
+                let Value::String(string) = &tuple[idx] else {
+                    panic!("Expected data type TEXT but found {}", tuple[idx]);
+                };
+
+                let len = string.as_bytes().len();
+                let header_len = varlena_header_len(len as _);
+                header_len + len
+            }
             other => byte_len_of_type(&other),
         })
         .sum()

--- a/src/core/storage/tuple.rs
+++ b/src/core/storage/tuple.rs
@@ -42,6 +42,18 @@ pub(in crate::core::storage) const fn utf_8_length_bytes(max_size: usize) -> usi
     }
 }
 
+/// Returns the size in bytes of the varlena header, given its first byte.
+/// If the first byte less than 127: 1-byte header (short string, length is the first byte)
+/// If the first byte greater or equal to 128: 4-byte header (long string, length is in the next 3 bytes)
+///
+/// *Note*: the first byte being equal to 0x7f is reserved and cannot be used.
+const fn varlena_header_len(byte: u8) -> usize {
+    match byte < 0x7f {
+        true => 1,
+        false => 4,
+    }
+}
+
 pub(crate) fn deserialize(buff: &[u8], schema: &Schema) -> Vec<Value> {
     read_from(&mut io::Cursor::new(buff), schema).unwrap()
 }

--- a/src/core/storage/tuple.rs
+++ b/src/core/storage/tuple.rs
@@ -157,72 +157,87 @@ pub(crate) fn read_from(reader: &mut impl Read, schema: &Schema) -> io::Result<V
                 String::from_utf8(string).expect("Couldn't parse string from utf8"),
             ))
         }
+
+        Type::Text => unimplemented!(),
+
         Type::Boolean => {
             let mut byte = [0; byte_len_of_type(&Type::Boolean)];
             reader.read_exact(&mut byte)?;
             Ok(Value::Boolean(byte[0] != 0))
         }
+
         Type::SmallInt => {
             let mut buf = [0; byte_len_of_type(&Type::SmallInt)];
             reader.read_exact(&mut buf)?;
             let n = i16::from_be_bytes(buf) as i128;
             Ok(Value::Number(n))
         }
+
         Type::UnsignedSmallInt | Type::SmallSerial => {
             let mut buf = [0; byte_len_of_type(&Type::UnsignedSmallInt)];
             reader.read_exact(&mut buf)?;
             let n = u16::from_be_bytes(buf) as i128;
             Ok(Value::Number(n))
         }
+
         Type::Integer => {
             let mut buf = [0; byte_len_of_type(&Type::Integer)];
             reader.read_exact(&mut buf)?;
             let n = i32::from_be_bytes(buf) as i128;
             Ok(Value::Number(n))
         }
+
         Type::UnsignedInteger | Type::Serial => {
             let mut buf = [0; byte_len_of_type(&Type::UnsignedInteger)];
             reader.read_exact(&mut buf)?;
             let n = u32::from_be_bytes(buf) as i128;
             Ok(Value::Number(n))
         }
+
         Type::BigInteger => {
             let mut buf = [0; byte_len_of_type(&Type::BigInteger)];
             reader.read_exact(&mut buf)?;
             let n = i64::from_be_bytes(buf) as i128;
             Ok(Value::Number(n))
         }
+
         Type::UnsignedBigInteger | Type::BigSerial => {
             let mut buf = [0; byte_len_of_type(&Type::UnsignedBigInteger)];
             reader.read_exact(&mut buf)?;
             let n = u64::from_be_bytes(buf) as i128;
             Ok(Value::Number(n))
         }
+
         Type::Uuid => {
             let mut buf = [0; byte_len_of_type(&Type::Uuid)];
             reader.read_exact(&mut buf)?;
             Ok(Value::Uuid(Uuid::from_bytes(buf)))
         }
+
         Type::Real => {
             let mut bytes = [0; byte_len_of_type(&Type::Real)];
             reader.read_exact(&mut bytes)?;
             Ok(Value::Float(f32::from_be_bytes(bytes).into()))
         }
+
         Type::DoublePrecision => {
             let mut bytes = [0; byte_len_of_type(&Type::DoublePrecision)];
             reader.read_exact(&mut bytes)?;
             Ok(Value::Float(f64::from_be_bytes(bytes)))
         }
+
         Type::Date => {
             let mut bytes = [0; byte_len_of_type(&Type::Date)];
             reader.read_exact(&mut bytes)?;
             Ok(Value::Temporal(NaiveDate::try_from(bytes)?.into()))
         }
+
         Type::Time => {
             let mut bytes = [0; byte_len_of_type(&Type::Time)];
             reader.read_exact(&mut bytes)?;
             Ok(Value::Temporal(NaiveTime::from(bytes).into()))
         }
+
         Type::DateTime => {
             let mut date_bytes = [0; byte_len_of_type(&Type::Date)];
             reader.read_exact(&mut date_bytes)?;

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -3215,4 +3215,77 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn text_column_ordering() -> DatabaseResult {
+        let mut db = Database::default();
+        db.exec("CREATE TABLE users (id SERIAL PRIMARY KEY, name TEXT);")?;
+        db.exec("INSERT INTO users (name) VALUES ('Alice'), ('Bob'), ('Carol');")?;
+
+        let query = db.exec("SELECT name FROM users ORDER BY name DESC;")?;
+        assert_eq!(
+            query.tuples,
+            vec![
+                vec!["Carol".into()],
+                vec!["Bob".into()],
+                vec!["Alice".into()]
+            ]
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn text_string_functions() -> DatabaseResult {
+        let mut db = Database::default();
+        db.exec("CREATE TABLE users (id INT PRIMARY KEY, name TEXT);")?;
+        db.exec("INSERT INTO users (id, name) VALUES (1, 'alice'), (2, 'bob'), (3, 'carol'), (4, 'dave');")?;
+
+        let query = db.exec("SELECT SUBSTRING(name FROM 2 FOR 2) FROM users ORDER BY id;")?;
+        assert_eq!(
+            query.tuples,
+            vec![
+                vec!["li".into()],
+                vec!["ob".into()],
+                vec!["ar".into()],
+                vec!["av".into()]
+            ]
+        );
+
+        let query = db.exec("SELECT CONCAT(name, '_user') FROM users ORDER BY id;")?;
+        assert_eq!(
+            query.tuples,
+            vec![
+                vec!["alice_user".into()],
+                vec!["bob_user".into()],
+                vec!["carol_user".into()],
+                vec!["dave_user".into()]
+            ]
+        );
+
+        let query = db.exec("SELECT ASCII(name) FROM users ORDER BY id;")?;
+        assert_eq!(
+            query.tuples,
+            vec![
+                vec![('a' as i128).into()],
+                vec![('b' as i128).into()],
+                vec![('c' as i128).into()],
+                vec![('d' as i128).into()],
+            ]
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn text_column_filtering() -> DatabaseResult {
+        let mut db = Database::default();
+        db.exec("CREATE TABLE users (id SERIAL PRIMARY KEY, name TEXT);")?;
+        db.exec("INSERT INTO users (name) VALUES ('Alice'), ('Bob'), ('Carol');")?;
+
+        let query = db.exec("SELECT name FROM users WHERE name LIKE 'A%';")?;
+        assert_eq!(query.tuples, vec![vec!["Alice".into()]]);
+
+        Ok(())
+    }
 }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -3192,4 +3192,27 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn text_column() -> DatabaseResult {
+        let mut db = Database::default();
+        db.exec("CREATE TABLE notes (id SERIAL PRIMARY KEY, title VARCHAR(100), content TEXT);")?;
+        db.exec(r#"
+        INSERT INTO notes (title, content) VALUES
+            ('Meeting Notes', 'Discussed project timeline and deliverables. Team agreed on Q2 launch.'),
+            ('Ideas', 'Consider adding dark mode to the application. Users have requested this feature.'),
+            ('Reminder', 'Call dentist on Monday to schedule annual checkup.');
+        "#)?;
+
+        let query = db.exec("SELECT title, content FROM notes WHERE content LIKE '%project%';")?;
+        assert_eq!(
+            query.tuples,
+            vec![vec![
+                "Meeting Notes".into(),
+                "Discussed project timeline and deliverables. Team agreed on Q2 launch.".into()
+            ]]
+        );
+
+        Ok(())
+    }
 }

--- a/src/sql/analyzer.rs
+++ b/src/sql/analyzer.rs
@@ -257,7 +257,7 @@ fn analyze_assignment<'exp, 'id>(
     };
 
     if expect_type.ne(&evaluate_type) {
-        print!("expected {expect_type:#?}");
+        println!("expected {expect_type:#?} found {value}");
         return Err(SqlError::Type(TypeError::ExpectedType {
             expected: expect_type,
             found: value.clone(),
@@ -427,6 +427,7 @@ fn analyze_where<'exp>(
 }
 
 fn analyze_string<'exp>(s: &str, expected_type: &Type) -> Result<VmType, SqlError> {
+    println!("expected {expected_type}");
     match expected_type {
         Type::Date => {
             NaiveDate::parse_str(s)?;

--- a/src/sql/analyzer.rs
+++ b/src/sql/analyzer.rs
@@ -257,7 +257,6 @@ fn analyze_assignment<'exp, 'id>(
     };
 
     if expect_type.ne(&evaluate_type) {
-        println!("expected {expect_type:#?} found {value}");
         return Err(SqlError::Type(TypeError::ExpectedType {
             expected: expect_type,
             found: value.clone(),

--- a/src/sql/analyzer.rs
+++ b/src/sql/analyzer.rs
@@ -257,6 +257,7 @@ fn analyze_assignment<'exp, 'id>(
     };
 
     if expect_type.ne(&evaluate_type) {
+        print!("expected {expect_type:#?}");
         return Err(SqlError::Type(TypeError::ExpectedType {
             expected: expect_type,
             found: value.clone(),
@@ -286,14 +287,7 @@ pub(in crate::sql) fn analyze_expression<'exp, 'sch>(
                 .index_of(ident)
                 .ok_or(SqlError::InvalidColumn(ident.to_string()))?;
 
-            match schema.columns[idx].data_type {
-                Type::Boolean => VmType::Bool,
-                Type::Varchar(_) | Type::Uuid => VmType::String,
-                Type::Date | Type::DateTime | Type::Time => VmType::Date,
-                float if float.is_float() => VmType::Float,
-                number if number.is_integer() => VmType::Number,
-                _ => unreachable!("this type is not defined for analyze_expression"),
-            }
+            (&schema.columns[idx].data_type).into()
         }
 
         Expression::BinaryOperation {

--- a/src/sql/parser/mod.rs
+++ b/src/sql/parser/mod.rs
@@ -351,6 +351,7 @@ impl<'input> Parser<'input> {
             Keyword::Timestamp => Ok(Type::DateTime),
             Keyword::Date => Ok(Type::Date),
             Keyword::Time => Ok(Type::Time),
+            Keyword::Text => Ok(Type::Text),
             keyword => unreachable!("unexpected column token: {keyword}"),
         }
     }
@@ -1841,4 +1842,3 @@ mod tests {
         )
     }
 }
-

--- a/src/sql/parser/mod.rs
+++ b/src/sql/parser/mod.rs
@@ -650,7 +650,7 @@ impl<'input> Parser<'input> {
         ]
     }
 
-    const fn supported_types() -> [Keyword; 14] {
+    const fn supported_types() -> [Keyword; 15] {
         [
             Keyword::SmallSerial,
             Keyword::Serial,
@@ -663,6 +663,7 @@ impl<'input> Parser<'input> {
             Keyword::Uuid,
             Keyword::Bool,
             Keyword::Varchar,
+            Keyword::Text,
             Keyword::Time,
             Keyword::Date,
             Keyword::Timestamp,
@@ -1620,8 +1621,7 @@ mod tests {
             })
         )
     }
-  
-  
+
     #[test]
     fn test_abs_func() {
         let sql = "SELECT ABS(amount) FROM payments;";
@@ -1708,8 +1708,7 @@ mod tests {
             })
         )
     }
-  
-  
+
     #[test]
     fn test_explicit_order_by() {
         let sql = "SELECT CONCAT(first_name, ' ', last_name) FROM users ORDER BY last_name DESC;";
@@ -1823,4 +1822,23 @@ mod tests {
             })
         )
     }
+
+    #[test]
+    fn test_text_column() {
+        let sql = "CREATE TABLE notes (id SERIAL PRIMARY KEY, content TEXT, created_at TIMESTAMP);";
+        let statement = Parser::new(sql).parse_statement();
+
+        assert_eq!(
+            statement.unwrap(),
+            Statement::Create(Create::Table {
+                name: "notes".into(),
+                columns: vec![
+                    Column::primary_key("id", Type::Serial),
+                    Column::new("content", Type::Text),
+                    Column::new("created_at", Type::DateTime)
+                ]
+            })
+        )
+    }
 }
+

--- a/src/sql/parser/tokens.rs
+++ b/src/sql/parser/tokens.rs
@@ -99,6 +99,7 @@ pub enum Keyword {
     Uuid,
     Unsigned,
     Varchar,
+    Text,
     Bool,
     True,
     False,
@@ -161,7 +162,7 @@ impl Display for Token {
 
 impl Whitespace {
     pub(in crate::sql) fn as_char(&self) -> char {
-         match self {
+        match self {
             Self::Tab => '\t',
             Self::Space => ' ',
             Self::Newline => '\n',
@@ -177,7 +178,7 @@ impl Display for Whitespace {
 
 impl Keyword {
     pub fn as_optional(&self) -> Option<Keyword> {
-         match self {
+        match self {
             Self::None => None,
             _ => Some(*self),
         }
@@ -236,6 +237,7 @@ impl Borrow<str> for Keyword {
             Self::Uuid => "UUID",
             Self::Unsigned => "UNSIGNED",
             Self::Varchar => "VARCHAR",
+            Self::Text => "TEXT",
             Self::Bool => "BOOLEAN",
             Self::True => "TRUE",
             Self::False => "FALSE",
@@ -330,6 +332,7 @@ impl FromStr for Keyword {
             "OWNED" => Keyword::Owned,
             "UNSIGNED" => Keyword::Unsigned,
             "VARCHAR" => Keyword::Varchar,
+            "TEXT" => Keyword::Text,
             "BOOLEAN" => Keyword::Bool,
             "INDEX" => Keyword::Index,
             "ORDER" => Keyword::Order,

--- a/src/sql/statement.rs
+++ b/src/sql/statement.rs
@@ -378,7 +378,7 @@ impl Type {
             | Self::Integer
             | Self::UnsignedInteger
             | Self::BigInteger
-            | Self::UnsignedBigInteger => true, // uuid in the end is just an integer number
+            | Self::UnsignedBigInteger => true,
             _ => self.is_serial(),
         }
     }

--- a/src/sql/statement.rs
+++ b/src/sql/statement.rs
@@ -267,6 +267,8 @@ pub enum Type {
     Boolean,
     /// Variable length character type with a limit
     Varchar(usize),
+    /// Variable unlimited length
+    Text,
     /// 4-byte variable-precision floating point type.
     Real,
     /// 8-byte variable-precision floating point type.
@@ -744,6 +746,7 @@ impl Display for Type {
             Type::Time => f.write_str("TIME"),
             Type::Date => f.write_str("DATE"),
             Type::Varchar(max) => write!(f, "VARCHAR({max})"),
+            Type::Text => write!(f, "TEXT"),
         }
     }
 }

--- a/src/tcp/protocol.rs
+++ b/src/tcp/protocol.rs
@@ -84,14 +84,14 @@ pub fn deserialize(content: &[u8]) -> Result<Response, EncodingError> {
                 cursor += name_len;
 
                 let data_type = match content[cursor] {
-                    // TODO: add parsing for text too
-                    STRING_CATEGORY | 0x0 => {
+                    byte if byte == STRING_CATEGORY | 0x0 => {
                         let mut buff = [0; 4];
                         buff.copy_from_slice(&content[cursor + 1..cursor + 5]);
                         let max_chars = u32::from_le_bytes(buff) as usize;
                         cursor += 4;
                         Type::Varchar(max_chars)
                     }
+                    byte if byte == STRING_CATEGORY | 0x1 => Type::Text,
 
                     content => {
                         Type::try_from(&content).map_err(|_| EncodingError::InvalidType(content))?

--- a/src/tcp/protocol.rs
+++ b/src/tcp/protocol.rs
@@ -84,6 +84,7 @@ pub fn deserialize(content: &[u8]) -> Result<Response, EncodingError> {
                 cursor += name_len;
 
                 let data_type = match content[cursor] {
+                    // TODO: add parsing for text too
                     STRING_CATEGORY | 0x0 => {
                         let mut buff = [0; 4];
                         buff.copy_from_slice(&content[cursor + 1..cursor + 5]);
@@ -153,6 +154,7 @@ impl From<&Type> for u8 {
             Type::DoublePrecision => FLOAT_CATEGORY | 0x1,
 
             Type::Varchar(_) => STRING_CATEGORY | 0x0,
+            Type::Text => STRING_CATEGORY | 0x1,
 
             Type::Date => TEMPORAL_CATEGORY | 0x0,
             Type::Time => TEMPORAL_CATEGORY | 0x1,

--- a/src/vm/expression.rs
+++ b/src/vm/expression.rs
@@ -320,10 +320,11 @@ impl From<&Type> for VmType {
     fn from(value: &Type) -> Self {
         match value {
             Type::Boolean => VmType::Bool,
-            Type::Varchar(_) => VmType::String,
-            Type::Time | Type::Date | Type::DateTime => VmType::Date,
-            Type::Real | Type::DoublePrecision => VmType::Float,
-            _ => VmType::Number,
+            Type::Varchar(_) | Type::Uuid | Type::Text => VmType::String,
+            Type::Date | Type::DateTime | Type::Time => VmType::Date,
+            float if float.is_float() => VmType::Float,
+            number if number.is_integer() || number.is_serial() => VmType::Number,
+            _ => panic!("Cannot convert type {value} to VmType"),
         }
     }
 }

--- a/src/vm/expression.rs
+++ b/src/vm/expression.rs
@@ -320,10 +320,12 @@ impl From<&Type> for VmType {
     fn from(value: &Type) -> Self {
         match value {
             Type::Boolean => VmType::Bool,
-            Type::Varchar(_) | Type::Uuid | Type::Text => VmType::String,
+            Type::Varchar(_) | Type::Text => VmType::String,
             Type::Date | Type::DateTime | Type::Time => VmType::Date,
             float if float.is_float() => VmType::Float,
-            number if number.is_integer() || number.is_serial() => VmType::Number,
+            number if matches!(number, Type::Uuid) || number.is_integer() || number.is_serial() => {
+                VmType::Number
+            }
             _ => panic!("Cannot convert type {value} to VmType"),
         }
     }

--- a/src/vm/expression.rs
+++ b/src/vm/expression.rs
@@ -98,6 +98,7 @@ pub(crate) fn resolve_expression<'exp>(
             let (left, right) = try_coerce(left, right);
 
             let mismatched_types = || {
+                println!("left {left} right {right}");
                 SqlError::Type(TypeError::CannotApplyBinary {
                     left: Expression::Value(left.clone()),
                     operator: *operator,
@@ -337,7 +338,7 @@ impl PartialEq for VmType {
             // we do this for coercion properties
             (VmType::Float, VmType::Number) | (VmType::Number, VmType::Float) => true,
             (VmType::String, VmType::Date) | (VmType::Date, VmType::String) => true,
-            //(VmType::String, VmType::Number) | (VmType::Number, VmType::String) => true,
+            // (VmType::String, VmType::Number) | (VmType::Number, VmType::String) => true,
             _ => mem::discriminant(self) == mem::discriminant(other),
         }
     }


### PR DESCRIPTION
This pull request introduces support for the `TEXT` data type in the Umbra database, enhancing its capabilities for handling variable-length strings without predefined limits. Key changes include updates to the binary protocol, serialisation/deserialisation logic, SQL parsing, and extensive test coverage.

### Support for `TEXT` data type:

#### Protocol updates:
* [`PROTOCOL.md`](diffhunk://#diff-62d56fa1c25dda8d49ccdbf9ea31df4576f84625706d54613dff0acc8f974d97R71): Added `TEXT` type (code `0x41`) to the binary protocol specification. Updated message structure sections to include line breaks for readability. [[1]](diffhunk://#diff-62d56fa1c25dda8d49ccdbf9ea31df4576f84625706d54613dff0acc8f974d97R71) [[2]](diffhunk://#diff-62d56fa1c25dda8d49ccdbf9ea31df4576f84625706d54613dff0acc8f974d97R11-R20) [[3]](diffhunk://#diff-62d56fa1c25dda8d49ccdbf9ea31df4576f84625706d54613dff0acc8f974d97R30-R32)

#### Core storage logic:
* [`src/core/storage/tuple.rs`](diffhunk://#diff-2b29c1d5c0ad22de770a86fb5bac0ddbadcbc81edddcfc42b7f2ddaeaa97e17eR45-R56): Implemented serialisation and deserialisation logic for `TEXT` type using a varlena header format. Added `varlena_header_len` helper function to determine header size based on the first byte. Updated `size_of` function to calculate tuple size for `TEXT` fields. [[1]](diffhunk://#diff-2b29c1d5c0ad22de770a86fb5bac0ddbadcbc81edddcfc42b7f2ddaeaa97e17eR45-R56) [[2]](diffhunk://#diff-2b29c1d5c0ad22de770a86fb5bac0ddbadcbc81edddcfc42b7f2ddaeaa97e17eR81-R96) [[3]](diffhunk://#diff-2b29c1d5c0ad22de770a86fb5bac0ddbadcbc81edddcfc42b7f2ddaeaa97e17eR167-R175) [[4]](diffhunk://#diff-2b29c1d5c0ad22de770a86fb5bac0ddbadcbc81edddcfc42b7f2ddaeaa97e17eR197-R296)
* [`src/core/storage/tuple.rs`](diffhunk://#diff-2b29c1d5c0ad22de770a86fb5bac0ddbadcbc81edddcfc42b7f2ddaeaa97e17eR344-R379): Added tests for `TEXT` type round-trip serialisation/deserialisation, covering edge cases like empty strings, multi-byte characters, and large strings.

#### SQL parsing and analysis:
* [`src/sql/parser/mod.rs`](diffhunk://#diff-a7b1e24649e031a6c54175d07c33c7818188d3f8429883f8bf46e0024831efc7R354): Added `TEXT` as a supported SQL type, updated keyword mappings, and expanded test cases to verify parsing of `TEXT` columns. [[1]](diffhunk://#diff-a7b1e24649e031a6c54175d07c33c7818188d3f8429883f8bf46e0024831efc7R354) [[2]](diffhunk://#diff-a7b1e24649e031a6c54175d07c33c7818188d3f8429883f8bf46e0024831efc7L653-R654) [[3]](diffhunk://#diff-a7b1e24649e031a6c54175d07c33c7818188d3f8429883f8bf46e0024831efc7R667) [[4]](diffhunk://#diff-a7b1e24649e031a6c54175d07c33c7818188d3f8429883f8bf46e0024831efc7R1826-R1843)
* [`src/sql/analyzer.rs`](diffhunk://#diff-5df247c7fc38204a2031d4440728990d67a9234e99cc217d43a08236f277d3bcL289-R293): Updated type analysis logic to handle `TEXT` columns. Added debug logging for type mismatches and expected types. [[1]](diffhunk://#diff-5df247c7fc38204a2031d4440728990d67a9234e99cc217d43a08236f277d3bcL289-R293) [[2]](diffhunk://#diff-5df247c7fc38204a2031d4440728990d67a9234e99cc217d43a08236f277d3bcR306) [[3]](diffhunk://#diff-5df247c7fc38204a2031d4440728990d67a9234e99cc217d43a08236f277d3bcR435)

### Test coverage enhancements:
* [`src/db/mod.rs`](diffhunk://#diff-e9741181f28cc836cabf59de4e08abad911f880a23a4dc3ac0149de7452d5114R3195-R3290): Added integration tests for `TEXT` columns, including filtering, ordering, string functions (e.g., `SUBSTRING`, `CONCAT`, `ASCII`), and `LIKE` queries.
* [`src/sql/analyzer.rs`](diffhunk://#diff-5df247c7fc38204a2031d4440728990d67a9234e99cc217d43a08236f277d3bcR1040-R1092): Added tests for inserting empty and large `TEXT` values, and analysing `TEXT` columns in `WHERE` clauses.

### Miscellaneous updates:
* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L4-R4): Bumped version from `1.7.0` to `1.7.1`.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L142-R142): Updated feature checklist to mark `TEXT` as supported.