### PR TITLE
fix: correct aliasing behaviour on some unusual cases

### DIFF
--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -3175,11 +3175,10 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "the future will say"]
     fn alias_with_order_by() -> DatabaseResult {
         let mut db = Database::default();
         db.exec("CREATE TABLE users (id SERIAL PRIMARY KEY, name VARCHAR(30), age INT UNSIGNED);")?;
-        db.exec("INSERT INTO users (age, name) VALUES (19, 'Jonh Doe'), (23, 'Mary Dove');")?;
+        db.exec("INSERT INTO users (age, name) VALUES (19, 'John Doe'), (23, 'Mary Dove');")?;
 
         let query = db.exec("SELECT name as user_name, age FROM users ORDER BY user_name;")?;
         assert_eq!(

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -3236,25 +3236,25 @@ mod tests {
             query.tuples,
             vec![
                 vec![
-                    Value::String("Engineering".into()),
-                    Value::Number(3),
-                    Value::Float(88333.3),
-                    Value::Number(9),
-                    Value::String("2018-03-10".into())
+                    "Engineering".into(),
+                    3.into(),
+                    88333.3f64.into(),
+                    9.into(),
+                    temporal!("2018-03-10")?,
                 ],
                 vec![
-                    Value::String("Marketing".into()),
-                    Value::Number(2),
-                    Value::Float(75000.0),
-                    Value::Number(8),
-                    Value::String("2019-11-20".into())
+                    "Marketing".into(),
+                    2.into(),
+                    75000f64.into(),
+                    8.into(),
+                    temporal!("2019-11-20")?,
                 ],
                 vec![
-                    Value::String("HR".into()),
-                    Value::Number(1),
-                    Value::Float(68000.0),
-                    Value::Number(6),
-                    Value::String("2021-01-05".into())
+                    "HR".into(),
+                    1.into(),
+                    68000f64.into(),
+                    6.into(),
+                    temporal!("2021-01-05")?,
                 ]
             ]
         );

--- a/src/sql/analyzer.rs
+++ b/src/sql/analyzer.rs
@@ -12,9 +12,14 @@ use crate::sql::statement::{
     BinaryOperator, Constraint, Create, Drop, Expression, Statement, Type, UnaryOperator, Value,
 };
 use crate::vm::expression::{TypeError, VmType};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fmt::Display;
 use std::str::FromStr;
+
+struct AliasCtx<'s> {
+    schema: &'s Schema,
+    aliases: &'s HashMap<String, &'s Expression>,
+}
 
 #[derive(Debug, PartialEq)]
 pub enum AnalyzerError {
@@ -35,6 +40,10 @@ pub enum AlreadyExists {
 }
 
 type AnalyzerResult<'exp, T> = Result<T, DatabaseError>;
+
+pub(in crate::sql) trait AnalyzeCtx {
+    fn resolve_identifier(&self, ident: &str) -> Option<(usize, &Type)>;
+}
 
 pub(in crate::sql) fn analyze<'s>(
     statement: &'s Statement,
@@ -168,6 +177,14 @@ pub(in crate::sql) fn analyze<'s>(
         }) => {
             let metadata = ctx.metadata(from)?;
 
+            let aliases: HashMap<String, &Expression> = columns
+                .iter()
+                .filter_map(|column_expr| match column_expr {
+                    Expression::Alias { expr, alias } => Some((alias.clone(), expr.as_ref())),
+                    _ => None,
+                })
+                .collect();
+
             for expr in columns {
                 let expr = expr.unwrap_alias();
 
@@ -189,11 +206,11 @@ pub(in crate::sql) fn analyze<'s>(
 
             // FIXME: we probably can do this in parallel
             for order in order_by {
-                analyze_expression(&metadata.schema, None, &order.expr)?;
+                analyze_expression_with_aliases(&metadata.schema, &aliases, None, &order.expr)?;
             }
 
             for expr in group_by {
-                analyze_expression(&metadata.schema, None, expr)?;
+                analyze_expression_with_aliases(&metadata.schema, &aliases, None, expr)?;
             }
         }
 
@@ -274,21 +291,41 @@ fn analyze_assignment<'exp, 'id>(
     Ok(())
 }
 
-pub(in crate::sql) fn analyze_expression<'exp, 'sch>(
-    schema: &'sch Schema,
-    col_type: Option<&Type>,
+impl AnalyzeCtx for Schema {
+    fn resolve_identifier(&self, ident: &str) -> Option<(usize, &Type)> {
+        self.index_of(ident)
+            .map(|idx| (idx, &self.columns[idx].data_type))
+    }
+}
+
+impl<'s> AnalyzeCtx for AliasCtx<'s> {
+    fn resolve_identifier(&self, ident: &str) -> Option<(usize, &Type)> {
+        if let Some(_) = self.aliases.get(ident) {
+            return None;
+        }
+
+        self.schema
+            .index_of(ident)
+            .map(|idx| (idx, &self.schema.columns[idx].data_type))
+    }
+}
+
+pub(in crate::sql) fn analyze_expression<'exp, Ctx: AnalyzeCtx>(
+    ctx: &Ctx,
+    data_type: Option<&Type>,
     expr: &'exp Expression,
 ) -> Result<VmType, SqlError> {
     Ok(match expr {
-        Expression::Value(value) => analyze_value(value, col_type)?,
+        Expression::Value(value) => analyze_value(value, data_type)?,
         Expression::Identifier(ident) => {
-            let idx = schema
-                .index_of(ident)
-                .ok_or(SqlError::InvalidColumn(ident.to_string()))?;
+            let data_type = ctx
+                .resolve_identifier(ident)
+                .map(|tuple| tuple.1)
+                .ok_or(SqlError::InvalidColumn(ident.into()))?;
 
             // this is an expection because when dealing with outside input, UUID's treated as a
             // String, but inside the engine, we treat it as a Number.
-            match &schema.columns[idx].data_type {
+            match data_type {
                 Type::Uuid => VmType::String,
                 r#type => r#type.into(),
             }
@@ -299,11 +336,10 @@ pub(in crate::sql) fn analyze_expression<'exp, 'sch>(
             left,
             right,
         } => {
-            let left_type = analyze_expression(schema, col_type, left)?;
-            let right_type = analyze_expression(schema, col_type, right)?;
+            let left_type = analyze_expression(ctx, data_type, left)?;
+            let right_type = analyze_expression(ctx, data_type, right)?;
 
             if left_type.ne(&right_type) {
-                println!("left {left_type:#?} right {right_type:#?}");
                 return Err(SqlError::Type(TypeError::CannotApplyBinary {
                     left: *left.clone(),
                     right: *right.clone(),
@@ -333,54 +369,73 @@ pub(in crate::sql) fn analyze_expression<'exp, 'sch>(
                 _ => unreachable!("unexpected operation state"),
             }
         }
+
         Expression::UnaryOperation { operator, expr } => {
             if let (Some(data_type), UnaryOperator::Minus, Expression::Value(value)) =
-                (col_type, operator, &**expr)
+                (data_type, operator, &**expr)
             {
                 match value {
-                    Value::Number(num) => {
-                        analyze_number(&-num, data_type)?;
+                    Value::Number(n) => {
+                        analyze_number(&-n, data_type)?;
                         return Ok(VmType::Number);
                     }
-                    Value::Float(float) => {
-                        analyze_float(&-float, data_type)?;
+                    Value::Float(f) => {
+                        analyze_float(&-f, data_type)?;
                         return Ok(VmType::Float);
                     }
                     _ => unreachable!(),
                 }
             }
 
-            match analyze_expression(schema, col_type, expr)? {
-                VmType::Number => VmType::Number,
-                VmType::Float => VmType::Float,
-                _ => Err(TypeError::ExpectedType {
+            match analyze_expression(ctx, data_type, expr)? {
+                VmType::Number | VmType::Float => VmType::Number,
+                _ => Err(SqlError::Type(TypeError::ExpectedType {
                     expected: VmType::Number,
                     found: *expr.clone(),
-                })?,
+                }))?,
             }
         }
+
         Expression::Function { func, args } => {
-            if let Some((min_args, max_args)) = func.size_of_args() {
-                if args.len() < min_args || args.len() > max_args {
-                    return Err(SqlError::InvalidFuncArgs(min_args, args.len()));
+            if let Some((min, max)) = func.size_of_args() {
+                if args.len() < min || args.len() > max {
+                    return Err(SqlError::InvalidFuncArgs(min, args.len()));
                 }
             }
 
             for arg in args {
                 if arg.ne(&Expression::Wildcard) {
-                    analyze_expression(schema, col_type, arg)?;
+                    analyze_expression(ctx, data_type, arg)?;
                 }
             }
 
             func.return_type()
         }
+
         Expression::Nested(expr) | Expression::Alias { expr, .. } => {
-            analyze_expression(schema, col_type, expr)?
+            analyze_expression(ctx, data_type, expr)?
         }
+
         Expression::Wildcard => {
             return Err(SqlError::Other("Unexpected wildcard expression (*)".into()))
         }
     })
+}
+
+fn analyze_expression_with_aliases<'exp>(
+    schema: &Schema,
+    aliases: &HashMap<String, &Expression>,
+    col_type: Option<&Type>,
+    expr: &'exp Expression,
+) -> Result<VmType, SqlError> {
+    if let Expression::Identifier(ident) = expr {
+        if let Some(aliases_expr) = aliases.get(ident) {
+            return analyze_expression_with_aliases(schema, aliases, col_type, &aliases_expr);
+        }
+    }
+
+    let ctx = AliasCtx { schema, aliases };
+    analyze_expression(&ctx, col_type, expr)
 }
 
 fn analyze_value<'exp>(value: &Value, col_type: Option<&Type>) -> Result<VmType, SqlError> {

--- a/src/sql/analyzer.rs
+++ b/src/sql/analyzer.rs
@@ -487,7 +487,6 @@ fn analyze_where<'exp>(
 }
 
 fn analyze_string<'exp>(s: &str, expected_type: &Type) -> Result<VmType, SqlError> {
-    println!("expected {expected_type}");
     match expected_type {
         Type::Date => {
             NaiveDate::parse_str(s)?;

--- a/src/sql/query/planner.rs
+++ b/src/sql/query/planner.rs
@@ -8,7 +8,7 @@ use crate::{
     core::storage::pagination::io::FileOperations,
     db::{Ctx, Database, DatabaseError, Schema, SqlError},
     sql::{
-        analyzer,
+        analyzer::{self, contains_aggregate},
         query::optimiser,
         statement::{Column, Delete, Expression, OrderBy, OrderDirection, Select, Type, Update},
         Statement,
@@ -90,10 +90,10 @@ pub(crate) fn generate_plan<File: Seek + Read + Write + FileOperations>(
             let aggr_exprs: Vec<(&Expression, String)> = columns
                 .iter()
                 .filter_map(|expr| match expr {
-                    Expression::Alias { ref alias, expr } if expr.is_aggr_fn() => {
+                    Expression::Alias { ref alias, expr } if contains_aggregate(expr) => {
                         Some((expr.as_ref(), alias.to_string()))
                     }
-                    expr if expr.is_aggr_fn() => Some((expr, expr.to_string())),
+                    expr if contains_aggregate(expr) => Some((expr, expr.to_string())),
                     _ => None,
                 })
                 .collect();
@@ -103,10 +103,26 @@ pub(crate) fn generate_plan<File: Seek + Read + Write + FileOperations>(
 
                 for expr in &group_by {
                     match expr {
-                        Expression::Identifier(ident) => aggr_schema
-                            .push(schema.columns[schema.index_of(ident).unwrap()].clone()),
-                        _ => aggr_schema
-                            .push(Column::new(&expr.to_string(), resolve_type(schema, expr)?)),
+                        Expression::Identifier(ident) => {
+                            if let Some(expr) = columns.iter().find_map(|col_expr| match col_expr {
+                                Expression::Alias { alias, expr } if alias == ident => {
+                                    Some(expr.as_ref())
+                                }
+                                _ => None,
+                            }) {
+                                aggr_schema.push(Column::new(ident, resolve_type(schema, expr)?));
+                            } else if let Some(idx) = schema.index_of(ident) {
+                                aggr_schema.push(schema.columns[idx].clone());
+                            } else {
+                                return Err(SqlError::InvalidColumn(ident.clone()).into());
+                            }
+                        }
+                        other => {
+                            aggr_schema.push(Column::new(
+                                &other.to_string(),
+                                resolve_type(schema, other)?,
+                            ));
+                        }
                     }
                 }
 
@@ -116,7 +132,7 @@ pub(crate) fn generate_plan<File: Seek + Read + Write + FileOperations>(
 
                 if group_by.is_empty() && !order_by.is_empty() {
                     let (indexes, directions) =
-                        extract_order_indexes_and_directions(schema, &order_by)?;
+                        extract_order_indexes_and_directions(schema, &columns, &order_by)?;
 
                     source = Planner::Sort(Sort::from(SortBuilder {
                         page_size,
@@ -137,12 +153,27 @@ pub(crate) fn generate_plan<File: Seek + Read + Write + FileOperations>(
                     }));
                 }
 
+                let resolved_group_by: Vec<Expression> = group_by
+                    .iter()
+                    .map(|expr| {
+                        if let Expression::Identifier(ident) = expr {
+                            for col_expr in &columns {
+                                if col_expr.unwrap_name().as_ref() == ident {
+                                    return (*col_expr).clone();
+                                }
+                            }
+                        }
+
+                        expr.clone()
+                    })
+                    .collect();
+
                 let mut plan = Planner::Aggregate(
                     AggregateBuilder {
                         source: Box::new(source),
                         aggr_exprs: aggr_exprs.iter().map(|expr| expr.0.clone()).collect(),
                         page_size,
-                        group_by: group_by.clone(),
+                        group_by: resolved_group_by,
                         output: aggr_schema.clone(),
                     }
                     .into(),
@@ -150,7 +181,7 @@ pub(crate) fn generate_plan<File: Seek + Read + Write + FileOperations>(
 
                 if is_grouped && !order_by.is_empty() {
                     let (indexes, directions) =
-                        extract_order_indexes_and_directions(&aggr_schema, &order_by)?;
+                        extract_order_indexes_and_directions(&aggr_schema, &columns, &order_by)?;
 
                     plan = Planner::Sort(Sort::from(SortBuilder {
                         page_size,
@@ -340,23 +371,36 @@ fn resolve_type(schema: &Schema, expr: &Expression) -> Result<Type, SqlError> {
 
 fn extract_order_indexes_and_directions(
     schema: &Schema,
+    columns: &[Expression],
     order_by: &[OrderBy],
 ) -> Result<(Vec<usize>, Vec<OrderDirection>), DatabaseError> {
     order_by
         .iter()
         .map(|order| {
             let idx = match &order.expr {
-                Expression::Identifier(ident) => schema
-                    .index_of(ident)
-                    .ok_or(SqlError::InvalidGroupBy(ident.into())),
+                Expression::Identifier(ident) => {
+                    for (i, expr) in columns.iter().enumerate() {
+                        if let Expression::Alias { alias, .. } = expr {
+                            if alias == ident {
+                                return Ok((i, order.direction));
+                            }
+                        }
+                    }
+
+                    schema
+                        .index_of(ident)
+                        .ok_or(SqlError::InvalidGroupBy(ident.into()))
+                        .map(|idx| (idx, order.direction))
+                }
                 _ => schema
                     .index_of(&order.expr.to_string())
                     .ok_or(SqlError::Other(format!(
                         "ORDER BY expression `{}` not found in output columns",
                         order.expr.to_string()
-                    ))),
+                    )))
+                    .map(|idx| (idx, order.direction)),
             }?;
-            Ok((idx, order.direction))
+            Ok(idx)
         })
         .collect::<Result<Vec<_>, _>>()
         .map(|p| p.into_iter().unzip())

--- a/src/sql/statement.rs
+++ b/src/sql/statement.rs
@@ -541,6 +541,14 @@ impl Expression {
     pub(in crate::sql) fn is_aggr_fn(&self) -> bool {
         matches!(self, Expression::Function { func, .. } if func.is_aggr())
     }
+
+    pub(in crate::sql) fn as_identifier(&self) -> Option<&str> {
+        if let Self::Identifier(alias) = self {
+            return Some(alias);
+        };
+
+        None
+    }
 }
 
 impl Default for Expression {


### PR DESCRIPTION
This pull request introduces enhancements to SQL query analysis and execution, focusing on better handling of aliases, group-by and order-by clauses, and aggregate functions. It also includes new test cases and bug fixes to improve the robustness of the database engine.

### Enhancements to SQL Query Analysis:
* Added an `AliasCtx` struct and the `AnalyzeCtx` trait to manage alias resolution during query analysis, improving the handling of aliases in group-by and order-by clauses (`src/sql/analyzer.rs`). [[1]](diffhunk://#diff-5df247c7fc38204a2031d4440728990d67a9234e99cc217d43a08236f277d3bcL15-R23) [[2]](diffhunk://#diff-5df247c7fc38204a2031d4440728990d67a9234e99cc217d43a08236f277d3bcR44-R47)
* Modified `analyze_expression` to use the new alias context and added a helper function `analyze_expression_with_aliases` for resolving aliases in expressions (`src/sql/analyzer.rs`). [[1]](diffhunk://#diff-5df247c7fc38204a2031d4440728990d67a9234e99cc217d43a08236f277d3bcL277-R358) [[2]](diffhunk://#diff-5df247c7fc38204a2031d4440728990d67a9234e99cc217d43a08236f277d3bcR402-R470)
* Introduced the `contains_aggregate` function to detect aggregate functions in expressions, replacing the previous `is_aggr_fn` method (`src/sql/analyzer.rs`, `src/sql/query/planner.rs`). [[1]](diffhunk://#diff-5df247c7fc38204a2031d4440728990d67a9234e99cc217d43a08236f277d3bcL277-R358) [[2]](diffhunk://#diff-17f3c6a06d02c4915af337565679a74ed74677750babcd2390788c13cec287d9L11-R11)

### Improvements to Query Planning:
* Enhanced the query planner to resolve aliases in group-by and order-by clauses by mapping identifiers to their corresponding expressions or schema columns (`src/sql/query/planner.rs`). [[1]](diffhunk://#diff-17f3c6a06d02c4915af337565679a74ed74677750babcd2390788c13cec287d9L106-R125) [[2]](diffhunk://#diff-17f3c6a06d02c4915af337565679a74ed74677750babcd2390788c13cec287d9R156-R184)
* Updated the `extract_order_indexes_and_directions` function to account for aliases in the order-by clause (`src/sql/query/planner.rs`).

### New Test Cases:
* Added a comprehensive test case, `complete_alias_with_group_and_order`, to validate the correct behaviour of aliases, group-by, and order-by clauses in complex queries (`src/db/mod.rs`).

### Bug Fixes and Refactoring:
* Fixed a typo in an existing test case (`alias_with_order_by`) by correcting a name in the test data (`src/db/mod.rs`).
* Refactored the `analyze_expression` function to improve readability and modularity, and removed unused debug statements (`src/sql/analyzer.rs`). [[1]](diffhunk://#diff-5df247c7fc38204a2031d4440728990d67a9234e99cc217d43a08236f277d3bcL302-L306) [[2]](diffhunk://#diff-5df247c7fc38204a2031d4440728990d67a9234e99cc217d43a08236f277d3bcL435)

### Other Changes:
* Added a helper method `as_identifier` to the `Expression` struct for extracting identifiers from expressions (`src/sql/statement.rs`).
* Updated the aggregate execution logic to preprocess aggregate expressions before resolving them (`src/vm/planner.rs`).