### PR TITLE
fix: functions with wrong arguments and returning types

### DIFF
--- a/src/core/storage/btree.rs
+++ b/src/core/storage/btree.rs
@@ -341,7 +341,7 @@ impl<'p, File: Read + Write + Seek + FileOperations, Cmp: BytesCmp> BTree<'p, Fi
             let cells = root.drain(..).collect::<Vec<_>>();
 
             let new_child = self.pager.get_mut(new_page)?;
-            cells.into_iter().for_each(|cell| new_child.push(cell));
+            new_child.push_all(cells);
             new_child.mutable_header().right_child = grandchild;
 
             parents.push(page_number);

--- a/src/core/storage/tuple.rs
+++ b/src/core/storage/tuple.rs
@@ -100,11 +100,20 @@ fn serialize_into(buff: &mut Vec<u8>, r#type: &Type, value: &Value) {
             let be_bytes = num.to_be_bytes();
             buff.extend_from_slice(&be_bytes[be_bytes.len() - b_len..]);
         }
-        (float, Value::Float(num)) if float.is_float() => match float {
-            Type::Real => buff.extend_from_slice(&(*num as f32).to_be_bytes()),
-            Type::DoublePrecision => buff.extend_from_slice(&num.to_be_bytes()),
-            _ => unreachable!("what kind of float is this?"),
-        },
+        (r#type, value) if r#type.is_float() || r#type.is_integer() => {
+            println!("type {} value {value}", r#type);
+            let float = match value {
+                Value::Number(num) => *num as f64,
+                Value::Float(num) => *num,
+                _ => unreachable!(),
+            };
+
+            match r#type {
+                Type::Real => buff.extend_from_slice(&(float as f32).to_be_bytes()),
+                Type::DoublePrecision => buff.extend_from_slice(&float.to_be_bytes()),
+                _ => unreachable!("what kind of float is this?"),
+            }
+        }
         (Type::Date, Value::String(date)) => NaiveDate::parse_str(date).unwrap().serialize(buff),
         (Type::Time, Value::String(time)) => NaiveTime::parse_str(time).unwrap().serialize(buff),
         (Type::DateTime, Value::String(datetime)) => {
@@ -116,7 +125,7 @@ fn serialize_into(buff: &mut Vec<u8>, r#type: &Type, value: &Value) {
             buff.extend_from_slice(uuid.as_ref())
         }
 
-        _ => unimplemented!("Tried to call serialize from {value} into {type}"),
+        _ => unimplemented!("Tried to call serialize from {value:#?} into {type:#?}"),
     }
 }
 

--- a/src/sql/query/planner.rs
+++ b/src/sql/query/planner.rs
@@ -363,8 +363,8 @@ fn resolve_type(schema: &Schema, expr: &Expression) -> Result<Type, SqlError> {
             VmType::Float => Type::DoublePrecision,
             VmType::Bool => Type::Boolean,
             VmType::Number => Type::BigInteger,
-            VmType::String => Type::Varchar(65535),
-            VmType::Date => Type::DateTime,
+            VmType::String => Type::Text,
+            VmType::Date => Type::Date,
         },
     })
 }
@@ -1200,7 +1200,7 @@ mod tests {
                         func: Function::Min,
                         args: vec![parse_expr("age")]
                     }],
-                    output: Schema::new(vec![Column::new("MIN", Type::DoublePrecision)]),
+                    output: Schema::new(vec![Column::new("MIN", Type::BigInteger)]),
                     page_size,
                 }
                 .into()

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -96,6 +96,8 @@ fn serialisation_and_deserialisation() -> Result<()> {
         ]
     );
 
+    println!("{:#?}", query.tuples);
+
     db.drop()?;
 
     Ok(())

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,0 +1,102 @@
+use umbra::db::{Database, DatabaseError, QuerySet};
+use umbra::sql::statement::Value;
+
+type Result<T> = std::result::Result<T, DatabaseError>;
+
+struct State {
+    db: Database<std::fs::File>,
+    path: std::path::PathBuf,
+}
+
+impl State {
+    fn new(path: impl AsRef<std::path::Path>) -> Self {
+        Self {
+            db: Database::init(&path).unwrap(),
+            path: path.as_ref().to_path_buf(),
+        }
+    }
+
+    fn exec(&mut self, sql: &str) -> Result<QuerySet> {
+        self.db.exec(sql)
+    }
+
+    fn drop(self) -> std::io::Result<()> {
+        drop(self.db);
+
+        std::fs::remove_file(self.path)
+    }
+}
+
+#[test]
+fn serialisation_and_deserialisation() -> Result<()> {
+    let mut db = State::new("test.db");
+
+    db.exec(
+        r#"
+            CREATE TABLE employees (
+                id SERIAL PRIMARY KEY,
+                name VARCHAR(30),
+                department VARCHAR(20),
+                salary DOUBLE PRECISION, 
+                hire_date DATE,
+                performance_rating INT
+            );"#,
+    )?;
+
+    db.exec(
+        r#"
+            INSERT INTO employees (name, department, salary, hire_date, performance_rating) VALUES
+                ('John Smith', 'Engineering', 85000.00, '2020-05-15', 8),
+                ('Jane Doe', 'Marketing', 72000.00, '2019-11-20', 7),
+                ('Mike Johnson', 'Engineering', 92000.00, '2018-03-10', 9),
+                ('Sarah Williams', 'HR', 68000.00, '2021-01-05', 6),
+                ('David Brown', 'Marketing', 78000.00, '2020-07-22', 8),
+                ('Emily Davis', 'Engineering', 88000.00, '2019-09-14', 7);
+        "#,
+    )?;
+
+    let query = db.exec(
+        r#"
+            SELECT 
+                department AS dept,
+                COUNT(*) AS employee_count,
+                TRUNC(AVG(salary), 1) AS avg_salary,
+                MAX(performance_rating) AS max_rating,
+                MIN(hire_date) AS earliest_hire
+            FROM employees
+            GROUP BY dept
+            ORDER BY avg_salary DESC;
+        "#,
+    )?;
+
+    assert_eq!(
+        query.tuples,
+        vec![
+            vec![
+                "Engineering".into(),
+                3.into(),
+                88333.3f64.into(),
+                9.into(),
+                Value::Temporal(("2018-03-10").try_into()?),
+            ],
+            vec![
+                "Marketing".into(),
+                2.into(),
+                75000f64.into(),
+                8.into(),
+                Value::Temporal(("2019-11-20").try_into()?),
+            ],
+            vec![
+                "HR".into(),
+                1.into(),
+                68000f64.into(),
+                6.into(),
+                Value::Temporal(("2021-01-05").try_into()?),
+            ]
+        ]
+    );
+
+    db.drop()?;
+
+    Ok(())
+}


### PR DESCRIPTION
This pull request introduces several enhancements and changes to the serialisation logic, SQL type handling, and testing infrastructure in the codebase. The key updates include refactoring serialisation logic using a new `ValueSerialize` trait, improving type resolution for SQL expressions, and adding integration tests for database serialisation and deserialisation.

### Serialisation Refactor:
* Introduced a new `ValueSerialize` trait to encapsulate serialisation logic for `String`, `i128`, `f64`, `Temporal`, `Uuid`, and `bool` types, simplifying `serialize_into` by delegating type-specific logic to the trait (`src/core/storage/tuple.rs`). [[1]](diffhunk://#diff-2b29c1d5c0ad22de770a86fb5bac0ddbadcbc81edddcfc42b7f2ddaeaa97e17eR20-R23) [[2]](diffhunk://#diff-2b29c1d5c0ad22de770a86fb5bac0ddbadcbc81edddcfc42b7f2ddaeaa97e17eR287-R383)

* Replaced type-specific match cases in `serialize_into` with calls to the `ValueSerialize` trait's `serialize` method, reducing code duplication and improving maintainability (`src/core/storage/tuple.rs`). [[1]](diffhunk://#diff-2b29c1d5c0ad22de770a86fb5bac0ddbadcbc81edddcfc42b7f2ddaeaa97e17eL69-R76) [[2]](diffhunk://#diff-2b29c1d5c0ad22de770a86fb5bac0ddbadcbc81edddcfc42b7f2ddaeaa97e17eL81-R94)

### SQL Type Handling:
* Updated type resolution to change `VmType::String` from `Varchar(65535)` to `Text` and `VmType::Date` from `DateTime` to `Date`, aligning with new SQL type expectations (`src/sql/query/planner.rs`).

* Adjusted test schemas to reflect the updated type mappings, ensuring compatibility with the new type system (`src/sql/query/planner.rs`).

### SQL Function Enhancements:
* Enhanced analysis of SQL functions like `MIN` and `MAX` to dynamically infer return types based on argument types, improving type accuracy in query execution (`src/sql/analyzer.rs`).

### Database Integration Testing:
* Added a comprehensive integration test to validate serialization and deserialization of database operations, including table creation, data insertion, and query execution (`tests/integration_test.rs`).

### Minor Updates:
* Replaced `into_iter().for_each` with a more efficient `push_all` method in B-tree cell management (`src/core/storage/btree.rs`).